### PR TITLE
Refactor(xySize, dxySize): Refactor xySize and dxySize.

### DIFF
--- a/src/imageReaderBMP.cpp
+++ b/src/imageReaderBMP.cpp
@@ -13,7 +13,9 @@ namespace NNet {
 // Extract the input data from the specified file and save the data in the data container.
 // Returns the nonzero image size if successful, else returns 0,0.
 //
-xySize ImageReaderBMP::getData(std::string const &filename, std::vector<float> &dataContainer, ColorChannel_t colorChannel)
+Utils::Vector2u32 ImageReaderBMP::data(std::string const &filename,
+                                std::vector<float> &data_container,
+                                ColorChannel_t channel)
 {
     FILE* f = fopen(filename.c_str(), "rb");
 
@@ -72,8 +74,8 @@ xySize ImageReaderBMP::getData(std::string const &filename, std::vector<float> &
     uint32_t rowLen_padded = (width*3 + 3) & (~3);
     std::unique_ptr<unsigned char[]> imageData {new unsigned char[rowLen_padded]};
 
-    dataContainer.clear();
-    dataContainer.assign(width * height, 0); // Pre-allocate to make random access easy
+    data_container.clear();
+    data_container.assign(width * height, 0); // Pre-allocate to make random access easy
 
     // Fill the data container with 8-bit data taken from the image data:
 
@@ -88,13 +90,13 @@ xySize ImageReaderBMP::getData(std::string const &filename, std::vector<float> &
         unsigned val = 0;
 
         for (uint32_t x = 0; x < width; ++x) {
-            if (colorChannel == NNet::R) {
+            if (channel == NNet::R) {
                 val = imageData[x * 3 + 2]; // Red
-            } else if (colorChannel == NNet::G) {
+            } else if (channel == NNet::G) {
                 val = imageData[x * 3 + 1]; // Green
-            } else if (colorChannel == NNet::B) {
+            } else if (channel == NNet::B) {
                 val = imageData[x * 3 + 0]; // Blue
-            } else if (colorChannel == NNet::BW) {
+            } else if (channel == NNet::BW) {
                 // Rounds down:
                 val = (unsigned)(0.3 * imageData[x*3 + 2] +   // Red
                                  0.6 * imageData[x*3 + 1] +   // Green
@@ -108,7 +110,7 @@ xySize ImageReaderBMP::getData(std::string const &filename, std::vector<float> &
             // range that we can input into the neural net:
             // Also we'll invert the rows so that the origin is the upper left at 0,0:
 
-            dataContainer[flattenXY(x, (height - y) - 1, height)] = pixelToNetworkInputRange(val);
+            data_container[flattenXY(x, (height - y) - 1, height)] = pixelToNetworkInputRange(val);
         }
     }
 

--- a/src/imageReaderDat.cpp
+++ b/src/imageReaderDat.cpp
@@ -43,8 +43,9 @@ struct datHeader
 // Extract the input data from the specified file and save the data in the data container.
 // Returns the nonzero image size if successful, else returns 0,0.
 //
-xySize ImageReaderDat::getData(std::string const &filename,
-            std::vector<float> &dataContainer, ColorChannel_t colorChannel)
+Utils::Vector2u32 ImageReaderDat::data(std::string const &filename,
+                                std::vector<float> &data_container,
+                                ColorChannel_t channel)
 {
     datHeader hdr;
 
@@ -71,7 +72,7 @@ xySize ImageReaderDat::getData(std::string const &filename,
 
     // Map the color channel enumeration to a channel index:
     uint32_t colorChannelNumber;
-    switch (colorChannel) {
+    switch (channel) {
     case NNet::R: colorChannelNumber = 0; break;
     case NNet::G: colorChannelNumber = 1; break;
     case NNet::B: colorChannelNumber = 2; break;
@@ -91,8 +92,8 @@ xySize ImageReaderDat::getData(std::string const &filename,
     f.seekg(hdr.offsetToData + colorChannelNumber * hdr.bytesPerElement * hdr.width * hdr.height);
 
     // Clear dataContainer and reserve enough space:
-    dataContainer.clear();
-    dataContainer.assign(hdr.width * hdr.height, 0.0);
+    data_container.clear();
+    data_container.assign(hdr.width * hdr.height, 0.0);
 
     if (hdr.bytesPerElement == sizeof(float)) {
         for (uint32_t y = 0; y < hdr.height; ++y) {
@@ -100,7 +101,7 @@ xySize ImageReaderDat::getData(std::string const &filename,
                 float n;
                 f.read((char *)&n, sizeof n);
                 fixEndianness(&n);
-                dataContainer[flattenXY(x, y, hdr.height)] = n;
+                data_container[flattenXY(x, y, hdr.height)] = n;
             }
         }
     } else if (hdr.bytesPerElement == sizeof(double)) {
@@ -109,7 +110,7 @@ xySize ImageReaderDat::getData(std::string const &filename,
                 double n;
                 f.read((char *)&n, sizeof n);
                 fixEndianness(&n);
-                dataContainer[flattenXY(x, y, hdr.height)] = (float)n;
+                data_container[flattenXY(x, y, hdr.height)] = (float)n;
             }
         }
     } else {

--- a/src/parseTopologyConfig.cpp
+++ b/src/parseTopologyConfig.cpp
@@ -25,7 +25,7 @@ topologyConfigSpec_t::topologyConfigSpec_t(void)
     radiusSpecified = false;
     tfSpecified = false;
 
-    size.depth = size.x = size.y = 0;
+    size.z = size.x = size.y = 0;
     channel = NNet::BW;
     radius.x = radius.y = 0;
     transferFunctionName.clear();
@@ -175,18 +175,18 @@ void extractConvolveFilterMatrix(topologyConfigSpec_t &params, std::istringstrea
 // Depth, if omitted, defaults to zero.
 // Y, if omitted, defaults to zero.
 //
-dxySize extractDxySize(std::istringstream &ss)
+Utils::Vector3u32 extractDxySize(std::istringstream &ss)
 {
     char ch;
-    dxySize size;
-    size.depth = 1;  // Default is 1 unless otherwise specified
+    Utils::Vector3u32 size;
+    size.z = 1;  // Default is 1 unless otherwise specified
 
     ss >> size.x;   // This may actually be the depth, we'll see
     auto pos = ss.tellg();
     ss >> ch;       // Test the next non-space char
     if (ch == '*') {
         // Depth dimension
-        size.depth = size.x; // That was the depth we read, not X
+        size.z = size.x; // That was the depth we read, not X
         size.x = 0;
         ss >> size.x;
         pos = ss.tellg();
@@ -206,10 +206,10 @@ dxySize extractDxySize(std::istringstream &ss)
 // format: X [x Y]
 // Y, if omitted, defaults to zero.
 //
-xySize extractXySize(std::istringstream &ss)
+Utils::Vector2u32 extractXySize(std::istringstream &ss)
 {
     char ch;
-    xySize size;
+    Utils::Vector2u32 size;
 
     ss >> size.x;
     auto pos = ss.tellg();
@@ -433,7 +433,7 @@ void consistency(vector<topologyConfigSpec_t> &params)
         // the previous spec:
         for (auto itp = it - 1; itp != params.begin(); --itp) {
             if (itp->layerName == spec.layerName) {
-                if (itp->size.depth != spec.size.depth
+                if (itp->size.z != spec.size.z
                         || itp->size.x != spec.size.x
                         || itp->size.y != spec.size.y) {
                     err << "Repeated layer spec for \"" << spec.layerName
@@ -462,7 +462,7 @@ void consistency(vector<topologyConfigSpec_t> &params)
             // of the matrix was already saved in spec. If this layer has depth > 1, we'll
             // replicate the matrix depth-1 more times:
 
-            for (uint32_t depth = 1; depth < spec.size.depth; ++depth) {
+            for (uint32_t depth = 1; depth < spec.size.z; ++depth) {
                 spec.flatConvolveMatrix.push_back(spec.flatConvolveMatrix[0]);
             }
         }
@@ -475,7 +475,7 @@ void consistency(vector<topologyConfigSpec_t> &params)
             std::for_each(flatMatrix.begin(), flatMatrix.end(), [](float &w) {
                 w = randomFloat() / 100.0f; // Do something more intelligent here
             });
-            spec.flatConvolveMatrix.assign(spec.size.depth, flatMatrix);
+            spec.flatConvolveMatrix.assign(spec.size.z, flatMatrix);
         }
     }
 
@@ -485,7 +485,7 @@ void consistency(vector<topologyConfigSpec_t> &params)
         throw exceptionConfigFile();
     }
 
-    if (params.back().isConvolutionNetworkLayer || params.back().size.depth > 1) {
+    if (params.back().isConvolutionNetworkLayer || params.back().size.z > 1) {
         err << "Output layer cannot be a convolution network layer" << endl;
         throw exceptionConfigFile();
     }

--- a/src/unitTest.cpp
+++ b/src/unitTest.cpp
@@ -158,7 +158,7 @@ void unitTestConfigParsers()
         ASSERT_EQ(specs[0].layerName, "input");
         ASSERT_EQ(specs[0].poolSize.x, 0);
         ASSERT_EQ(specs[0].poolSize.y, 0);
-        ASSERT_EQ(specs[0].size.depth, 1);
+        ASSERT_EQ(specs[0].size.z, 1);
         ASSERT_EQ(specs[0].size.x, 2);
         ASSERT_EQ(specs[0].size.y, 2);
 
@@ -171,7 +171,7 @@ void unitTestConfigParsers()
         ASSERT_EQ(specs[1].layerName, "output");
         ASSERT_EQ(specs[1].poolSize.x, 0);
         ASSERT_EQ(specs[1].poolSize.y, 0);
-        ASSERT_EQ(specs[1].size.depth, 1);
+        ASSERT_EQ(specs[1].size.z, 1);
         ASSERT_EQ(specs[1].size.x, 1);
         ASSERT_EQ(specs[1].size.y, 1);
         ASSERT_EQ(specs[1].transferFunctionName.size(), sizeof "tanh" - 1);
@@ -209,7 +209,7 @@ void unitTestConfigParsers()
     }
 
     {
-        LOG("Test dxySize: only X given");
+        LOG("Test Utils::Vector3u32: only X given");
 
         string config =
             "input size 3\n"
@@ -217,13 +217,13 @@ void unitTestConfigParsers()
 
         istringstream ss(config);
         auto specs = myNet.parseTopologyConfig(ss);
-        ASSERT_EQ(specs[0].size.depth, 1);
+        ASSERT_EQ(specs[0].size.z, 1);
         ASSERT_EQ(specs[0].size.x, 3);
         ASSERT_EQ(specs[0].size.y, 1);
     }
 
     {
-        LOG("Test dxySize(): depth and X given");
+        LOG("Test Utils::Vector3u32(): depth and X given");
 
         string config =
             "input size 1\n"
@@ -232,13 +232,13 @@ void unitTestConfigParsers()
 
         istringstream ss(config);
         auto specs = myNet.parseTopologyConfig(ss);
-        ASSERT_EQ(specs[1].size.depth, 4);
+        ASSERT_EQ(specs[1].size.z, 4);
         ASSERT_EQ(specs[1].size.x, 3);
         ASSERT_EQ(specs[1].size.y, 1);
     }
 
     {
-        LOG("Test dxySize: depth, X, and Y given");
+        LOG("Test Utils::Vector3u32: depth, X, and Y given");
 
         string config =
             "input size 1\n"
@@ -247,7 +247,7 @@ void unitTestConfigParsers()
 
         istringstream ss(config);
         auto specs = myNet.parseTopologyConfig(ss);
-        ASSERT_EQ(specs[1].size.depth, 4);
+        ASSERT_EQ(specs[1].size.z, 4);
         ASSERT_EQ(specs[1].size.x, 3);
         ASSERT_EQ(specs[1].size.y, 5);
     }
@@ -308,7 +308,7 @@ void unitTestConfigParsers()
         ASSERT_EQ(spec->layerName, "input");
         ASSERT_EQ(spec->poolSize.x, 0);
         ASSERT_EQ(spec->poolSize.y, 0);
-        ASSERT_EQ(spec->size.depth, 1);
+        ASSERT_EQ(spec->size.z, 1);
         ASSERT_EQ(spec->size.x, 1);
         ASSERT_EQ(spec->size.y, 1);
 
@@ -323,7 +323,7 @@ void unitTestConfigParsers()
         ASSERT_EQ(spec->layerName, "layer1");
         ASSERT_EQ(spec->poolSize.x, 0);
         ASSERT_EQ(spec->poolSize.y, 0);
-        ASSERT_EQ(spec->size.depth, 1);
+        ASSERT_EQ(spec->size.z, 1);
         ASSERT_EQ(spec->size.x, 1);
         ASSERT_EQ(spec->size.y, 1);
         ASSERT_EQ(spec->transferFunctionName.size(), sizeof "tanh" - 1);
@@ -339,7 +339,7 @@ void unitTestConfigParsers()
         ASSERT_EQ(spec->layerName, "layer2");
         ASSERT_EQ(spec->poolSize.x, 0);
         ASSERT_EQ(spec->poolSize.y, 0);
-        ASSERT_EQ(spec->size.depth, 1);
+        ASSERT_EQ(spec->size.z, 1);
         ASSERT_EQ(spec->size.x, 2);
         ASSERT_EQ(spec->size.y, 2);
         ASSERT_EQ(spec->transferFunctionName.size(), sizeof "tanh" - 1);
@@ -355,7 +355,7 @@ void unitTestConfigParsers()
         ASSERT_EQ(spec->layerName, "layer3");
         ASSERT_EQ(spec->poolSize.x, 0);
         ASSERT_EQ(spec->poolSize.y, 0);
-        ASSERT_EQ(spec->size.depth, 1);
+        ASSERT_EQ(spec->size.z, 1);
         ASSERT_EQ(spec->size.x, 7);
         ASSERT_EQ(spec->size.y, 8);
         ASSERT_EQ(spec->transferFunctionName.size(), sizeof "tanh" - 1);
@@ -371,7 +371,7 @@ void unitTestConfigParsers()
         ASSERT_EQ(spec->layerName, "layer4");
         ASSERT_EQ(spec->poolSize.x, 0);
         ASSERT_EQ(spec->poolSize.y, 0);
-        ASSERT_EQ(spec->size.depth, 1);
+        ASSERT_EQ(spec->size.z, 1);
         ASSERT_EQ(spec->size.x, 2);
         ASSERT_EQ(spec->size.y, 2);
         ASSERT_EQ(spec->transferFunctionName.size(), sizeof "tanh" - 1);
@@ -446,21 +446,21 @@ void unitTestConfigParsers()
         auto specs = myNet.parseTopologyConfig(ss);
 
         auto const *spec = specNamed(specs, "layer1");
-        ASSERT_EQ(spec->size.depth, 1);
+        ASSERT_EQ(spec->size.z, 1);
         ASSERT_EQ(spec->size.x, 2);
         ASSERT_EQ(spec->size.y, 3);
 
         spec = specNamed(specs, "layer3");
-        ASSERT_EQ(spec->size.depth, 1);
+        ASSERT_EQ(spec->size.z, 1);
         ASSERT_EQ(spec->size.x, 4);
         ASSERT_EQ(spec->size.y, 5);
 
         spec = specNamed(specs, "layer5");
-        ASSERT_EQ(spec->size.depth, 2);
+        ASSERT_EQ(spec->size.z, 2);
         ASSERT_EQ(spec->size.x, 3);
         ASSERT_EQ(spec->size.y, 4);
 
-        ASSERT_EQ(specs.back().size.depth, 1);
+        ASSERT_EQ(specs.back().size.z, 1);
         ASSERT_EQ(specs.back().size.x, 1);
         ASSERT_EQ(specs.back().size.y, 1);
     }
@@ -476,7 +476,7 @@ void unitTestConfigParsers()
         auto specs = myNet.parseTopologyConfig(ss);
 
         auto *spec = &specs[1];
-        ASSERT_EQ(spec->size.depth, 1);
+        ASSERT_EQ(spec->size.z, 1);
         ASSERT_EQ(spec->size.x, 1);
         ASSERT_EQ(spec->size.y, 1);
     }
@@ -580,7 +580,7 @@ void unitTestConfigParsers()
         auto specs = myNet.parseTopologyConfig(ss);
 
         auto *spec = &specs[1];
-        ASSERT_EQ(spec->size.depth, 10);
+        ASSERT_EQ(spec->size.z, 10);
         ASSERT_EQ(spec->size.x, 16);
         ASSERT_EQ(spec->size.y, 16);
         ASSERT_EQ(spec->kernelSize.x, 3);
@@ -620,7 +620,7 @@ void unitTestConfigParsers()
         auto specs = myNet.parseTopologyConfig(ss);
 
         auto *spec = &specs[1];
-        ASSERT_EQ(spec->size.depth, 10);
+        ASSERT_EQ(spec->size.z, 10);
         ASSERT_EQ(spec->poolMethod, POOL_MAX);
         ASSERT_EQ(spec->poolSize.x, 2);
         ASSERT_EQ(spec->poolSize.y, 3);
@@ -641,7 +641,7 @@ void unitTestConfigParsers()
         auto *spec = &specs[1];
         ASSERT_EQ(spec->kernelSize.x, 3);
         ASSERT_EQ(spec->kernelSize.y, 5);
-        ASSERT_EQ(spec->size.depth, 10);
+        ASSERT_EQ(spec->size.z, 10);
 
         ASSERT_EQ(spec->flatConvolveMatrix.size(), 10);
         ASSERT_EQ(spec->flatConvolveMatrix[0].size(), 3*5);
@@ -772,11 +772,11 @@ void unitTestNet()
         ASSERT_EQ(myNet.layers[1]->isConvolutionNetworkLayer, false);
         ASSERT_EQ(myNet.layers[1]->isPoolingLayer, false);
 
-        ASSERT_EQ(myNet.layers[0]->size.depth, 1);
+        ASSERT_EQ(myNet.layers[0]->size.z, 1);
         ASSERT_EQ(myNet.layers[0]->size.x, 1);
         ASSERT_EQ(myNet.layers[0]->size.y, 1);
 
-        ASSERT_EQ(myNet.layers[1]->size.depth, 1);
+        ASSERT_EQ(myNet.layers[1]->size.z, 1);
         ASSERT_EQ(myNet.layers[1]->size.x, 1);
         ASSERT_EQ(myNet.layers[1]->size.y, 1);
 
@@ -829,11 +829,11 @@ void unitTestNet()
         ASSERT_EQ(myNet.layers[1]->isConvolutionNetworkLayer, false);
         ASSERT_EQ(myNet.layers[1]->isPoolingLayer, false);
 
-        ASSERT_EQ(myNet.layers[0]->size.depth, 1);
+        ASSERT_EQ(myNet.layers[0]->size.z, 1);
         ASSERT_EQ(myNet.layers[0]->size.x, 8);
         ASSERT_EQ(myNet.layers[0]->size.y, 8);
 
-        ASSERT_EQ(myNet.layers[1]->size.depth, 1);
+        ASSERT_EQ(myNet.layers[1]->size.z, 1);
         ASSERT_EQ(myNet.layers[1]->size.x, 8);
         ASSERT_EQ(myNet.layers[1]->size.y, 8);
     }
@@ -1396,7 +1396,7 @@ void unitTestConvolutionNetworking()
         ASSERT_EQ(myNet.layers[2]->neurons[0].size(), 1);
 
         auto const &hl = *myNet.layers[1]; // Hidden layer (the convolution network layer)
-        ASSERT_EQ(hl.size.depth, 2);
+        ASSERT_EQ(hl.size.z, 2);
         ASSERT_EQ(hl.size.x, 1);
         ASSERT_EQ(hl.size.y, 1);
 
@@ -1468,7 +1468,7 @@ void unitTestConvolutionNetworking()
         ASSERT_EQ(myNet.layers[2]->neurons[0].size(), 1);
 
         auto const &hl = *myNet.layers[1]; // Hidden layer (the convolution network layer)
-        ASSERT_EQ(hl.size.depth, 2);
+        ASSERT_EQ(hl.size.z, 2);
         ASSERT_EQ(hl.size.x, 8);
         ASSERT_EQ(hl.size.y, 8);
 
@@ -1670,7 +1670,7 @@ void unitTestConvolutionNetworking()
         ASSERT_EQ(myNet1.layers[0]->neurons[0].size(), 32*32);
 
         auto const &input = *myNet1.layers[0];
-        ASSERT_EQ(input.size.depth, 1);
+        ASSERT_EQ(input.size.z, 1);
         ASSERT_EQ(input.neurons.size(), 1);
         ASSERT_EQ(input.neurons[0].size(), 32*32);
         ASSERT_EQ(input.neurons[0][0].backConnectionsIndices.size(), 0);
@@ -1679,20 +1679,20 @@ void unitTestConvolutionNetworking()
 
         // layerMix2 combines two source layers:
         auto const &layerMix2 = *layerNamed(myNet1, "layerMix2"); // size 4x4 from layerMix1 plus from layerGauss
-        ASSERT_EQ(layerMix2.size.depth, 1);
+        ASSERT_EQ(layerMix2.size.z, 1);
         ASSERT_EQ(layerMix2.neurons.size(), 1);
         ASSERT_EQ(layerMix2.neurons[0].size(), 4*4);
         ASSERT_EQ(layerMix2.neurons[0][flattenXY(2,2,4)].backConnectionsIndices.size(),
                   8*8 + 8*8 + 1); // two source layers plus a bias
 
         auto const &layerConv = *layerNamed(myNet1, "layerConv"); // size 10*32x32 from input convolve 7x7
-        ASSERT_EQ(layerConv.size.depth, 10);
+        ASSERT_EQ(layerConv.size.z, 10);
         ASSERT_EQ(layerConv.neurons.size(), 10);
         ASSERT_EQ(layerConv.neurons[0].size(), 32*32);
         ASSERT_EQ(layerConv.neurons[0][16*32+16].backConnectionsIndices.size(), 7*7);
 
         auto const &output = *myNet1.layers.back();
-        ASSERT_EQ(output.size.depth, 1);
+        ASSERT_EQ(output.size.z, 1);
         ASSERT_EQ(output.neurons.size(), 1);
         ASSERT_EQ(output.neurons[0].size(), 10);
         ASSERT_EQ(output.neurons[0][0].backConnectionsIndices.size(), 4*4 + 1);
@@ -2004,7 +2004,7 @@ void unitTestPooling()
         ASSERT_EQ(pl.poolMethod, NNet::POOL_MAX);
         ASSERT_EQ(pl.poolSize.x, 1);
         ASSERT_EQ(pl.poolSize.y, 1);
-        ASSERT_EQ(pl.size.depth, 1);
+        ASSERT_EQ(pl.size.z, 1);
         ASSERT_EQ(pl.size.x, 1);
         ASSERT_EQ(pl.size.y, 1);
 
@@ -2294,8 +2294,8 @@ void unitTestMisc()
         ASSERT_EQ(flattenXY(0, 1, 8), 1);
         ASSERT_EQ(flattenXY(1, 0, 8), 8);
 
-        dxySize dxySz;
-        dxySz.depth = 0;
+        Utils::Vector3u32 dxySz;
+        dxySz.z = 0;
         dxySz.x = 4;
         dxySz.y = 8;
         ASSERT_EQ(flattenXY(2, 3, dxySz), 2*8 + 3);

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,54 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+// C includes:
+#include <cstdint>
+
+namespace NNet {
+
+namespace Utils {
+
+/**
+ * Vector2
+ * Description:
+ * 2D Vector to hold dimensions.
+ *
+ * x - width
+ * y - height
+ */
+template<typename T>
+struct Vector2 {
+ public:
+  T x;
+  T y;
+
+  Vector2() : x(0), y(0) {}
+  Vector2(T x, T y) : x(x), y(y) {}
+};
+
+typedef Vector2<uint32_t> Vector2u32;
+
+/**
+ * Vector3
+ * Description:
+ * 3D Vector to hold dimensions.
+ *
+ * z - depth
+ */
+template<typename T>
+struct Vector3 : public Vector2<T> {
+ public:
+  T z;
+
+  Vector3() : Vector2<T>(), z(0) {}
+  Vector3(T x, T y, T z) : Vector2<T>(x, y), z(z) {}
+
+};
+
+typedef Vector3<uint32_t> Vector3u32;
+
+} // namespace
+
+} // namespace
+
+#endif // UTILS_H


### PR DESCRIPTION
I reemplazed xySize and dxySize with these new structs:
- Vector2<T>.
- Vector3<T>.

Both structs use C++ meta-programming features, the Vector3<T> struct
inherits from Vector2<T>.

I refactored too the ImageReader public function "getData()" to a less
typed name "data" and changed the parameters from camelCase to
camel_case.

In the next commits and pull request i will be doing a series of
refactorings, the next will probably be the unitTest module, in these
commits i will be using this commit [template](https://gist.github.com/jeandudey/34bfd30d2668fb572449) and using the Google C++ Style guide (which i strongly suggest to use).

Jean Pierre Dudey *<jeandudey* ***AT*** *hotmail* ***DOT*** *com>*